### PR TITLE
Add mobile motion control interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,22 @@
         color: #172b36;
       }
 
+      #interactButton {
+        font-family: monospace;
+        margin-top: 20px;
+        padding: 10px 18px;
+        border: 1px solid #172b36;
+        background: rgba(241, 246, 244, 0.8);
+        color: #172b36;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.1s ease;
+      }
+
+      #interactButton:active {
+        transform: scale(0.98);
+      }
+
       #made {
         text-align: center;
         line-height: 1.5;
@@ -72,6 +88,7 @@
     <div id="container">
       <canvas id="pongCanvas" width="600" height="600"></canvas>
       <div id="score"></div>
+      <button id="interactButton" hidden>Interact</button>
       <p id="made">
         made by
         <a href="https://koenvangilst.nl/labs/pong-wars">Koen van Gilst</a> | source on
@@ -96,6 +113,7 @@
     const canvas = document.getElementById("pongCanvas");
     const ctx = canvas.getContext("2d");
     const scoreElement = document.getElementById("score");
+    const interactButton = document.getElementById("interactButton");
 
     const DAY_COLOR = colorPalette.MysticMint;
     const DAY_BALL_COLOR = colorPalette.NocturnalExpedition;
@@ -278,6 +296,10 @@
         ball.y += ball.dy;
 
         addRandomness(ball);
+
+        if (ball === balls[1]) {
+          applyOrientationInfluence(ball);
+        }
       });
 
       handleBallCollisions();
@@ -288,5 +310,79 @@
 
     const FRAME_RATE = 100;
     setInterval(draw, 1000 / FRAME_RATE);
+
+    const isMobileDevice = /android|iphone|ipad|ipod/i.test(navigator.userAgent);
+
+    let motionEnabled = false;
+    let baselineOrientation = null;
+    const orientationOffset = { beta: 0, gamma: 0 };
+
+    function resetBaseline() {
+      baselineOrientation = null;
+      orientationOffset.beta = 0;
+      orientationOffset.gamma = 0;
+    }
+
+    function handleOrientation(event) {
+      if (!motionEnabled) return;
+
+      const beta = event.beta ?? 0;
+      const gamma = event.gamma ?? 0;
+
+      if (baselineOrientation === null) {
+        baselineOrientation = { beta, gamma };
+        orientationOffset.beta = 0;
+        orientationOffset.gamma = 0;
+        return;
+      }
+
+      orientationOffset.beta = beta - baselineOrientation.beta;
+      orientationOffset.gamma = gamma - baselineOrientation.gamma;
+    }
+
+    function applyOrientationInfluence(ball) {
+      if (!motionEnabled) return;
+
+      const curveStrength = 0.02;
+
+      ball.dx += orientationOffset.gamma * curveStrength;
+      ball.dy += orientationOffset.beta * curveStrength;
+
+      clampSpeed(ball);
+    }
+
+    if (isMobileDevice) {
+      interactButton.hidden = false;
+
+      interactButton.addEventListener("click", async () => {
+        if (motionEnabled) {
+          resetBaseline();
+          interactButton.textContent = "Motion recalibrated";
+          return;
+        }
+
+        resetBaseline();
+
+        try {
+          if (
+            typeof DeviceOrientationEvent !== "undefined" &&
+            typeof DeviceOrientationEvent.requestPermission === "function"
+          ) {
+            const permission = await DeviceOrientationEvent.requestPermission();
+            if (permission !== "granted") {
+              interactButton.textContent = "Permission denied";
+              return;
+            }
+          }
+
+          window.addEventListener("deviceorientation", handleOrientation, true);
+          motionEnabled = true;
+          interactButton.textContent = "Motion active";
+        } catch (error) {
+          console.error("Device orientation error", error);
+          interactButton.textContent = "Unavailable";
+        }
+      });
+    }
   </script>
 </html>


### PR DESCRIPTION
## Summary
- add a mobile-only Interact button that can request motion access
- capture device orientation as a baseline and apply tilt-driven curve control to the night ball

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68da60827b5c832f8bf0d7de1aed5657