### PR TITLE
Gate motion steering behind impulse threshold

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,22 @@
         color: #172b36;
       }
 
+      #interactButton {
+        font-family: monospace;
+        margin-top: 20px;
+        padding: 10px 18px;
+        border: 1px solid #172b36;
+        background: rgba(241, 246, 244, 0.8);
+        color: #172b36;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.1s ease;
+      }
+
+      #interactButton:active {
+        transform: scale(0.98);
+      }
+
       #made {
         text-align: center;
         line-height: 1.5;
@@ -72,6 +88,7 @@
     <div id="container">
       <canvas id="pongCanvas" width="600" height="600"></canvas>
       <div id="score"></div>
+      <button id="interactButton" hidden>Interact</button>
       <p id="made">
         made by
         <a href="https://koenvangilst.nl/labs/pong-wars">Koen van Gilst</a> | source on
@@ -96,6 +113,7 @@
     const canvas = document.getElementById("pongCanvas");
     const ctx = canvas.getContext("2d");
     const scoreElement = document.getElementById("score");
+    const interactButton = document.getElementById("interactButton");
 
     const DAY_COLOR = colorPalette.MysticMint;
     const DAY_BALL_COLOR = colorPalette.NocturnalExpedition;
@@ -201,12 +219,26 @@
     }
 
     function clampSpeed(ball) {
-      ball.dx = Math.min(Math.max(ball.dx, -MAX_SPEED), MAX_SPEED);
-      ball.dy = Math.min(Math.max(ball.dy, -MAX_SPEED), MAX_SPEED);
+      const speed = Math.hypot(ball.dx, ball.dy);
 
-      // Make sure the ball always maintains a minimum speed
-      if (Math.abs(ball.dx) < MIN_SPEED) ball.dx = ball.dx > 0 ? MIN_SPEED : -MIN_SPEED;
-      if (Math.abs(ball.dy) < MIN_SPEED) ball.dy = ball.dy > 0 ? MIN_SPEED : -MIN_SPEED;
+      if (speed === 0) {
+        ball.dx = MIN_SPEED;
+        ball.dy = 0;
+        return;
+      }
+
+      if (speed > MAX_SPEED) {
+        const scale = MAX_SPEED / speed;
+        ball.dx *= scale;
+        ball.dy *= scale;
+        return;
+      }
+
+      if (speed < MIN_SPEED) {
+        const scale = MIN_SPEED / speed;
+        ball.dx *= scale;
+        ball.dy *= scale;
+      }
     }
 
     function addRandomness(ball) {
@@ -278,6 +310,10 @@
         ball.y += ball.dy;
 
         addRandomness(ball);
+
+        if (ball === balls[1]) {
+          applyOrientationInfluence(ball);
+        }
       });
 
       handleBallCollisions();
@@ -288,5 +324,114 @@
 
     const FRAME_RATE = 100;
     setInterval(draw, 1000 / FRAME_RATE);
+
+    const isMobileDevice = /android|iphone|ipad|ipod/i.test(navigator.userAgent);
+
+    let motionEnabled = false;
+    let baselineOrientation = null;
+    const orientationOffset = { beta: 0, gamma: 0 };
+    const pendingImpulse = { x: 0, y: 0 };
+
+    function resetBaseline() {
+      baselineOrientation = null;
+      orientationOffset.beta = 0;
+      orientationOffset.gamma = 0;
+    }
+
+    function handleOrientation(event) {
+      if (!motionEnabled) return;
+
+      const beta = event.beta ?? 0;
+      const gamma = event.gamma ?? 0;
+
+      if (baselineOrientation === null) {
+        baselineOrientation = { beta, gamma };
+        orientationOffset.beta = 0;
+        orientationOffset.gamma = 0;
+        return;
+      }
+
+      const deltaBeta = beta - baselineOrientation.beta;
+      const deltaGamma = gamma - baselineOrientation.gamma;
+
+      const previousOffset = { ...orientationOffset };
+
+      const SMOOTHING = 0.15;
+      orientationOffset.beta += (deltaBeta - orientationOffset.beta) * SMOOTHING;
+      orientationOffset.gamma += (deltaGamma - orientationOffset.gamma) * SMOOTHING;
+
+      const offsetMagnitude = Math.hypot(orientationOffset.beta, orientationOffset.gamma);
+      const offsetChange = Math.hypot(
+        orientationOffset.beta - previousOffset.beta,
+        orientationOffset.gamma - previousOffset.gamma,
+      );
+
+      const MAGNITUDE_THRESHOLD = 10;
+      const CHANGE_THRESHOLD = 3;
+
+      if (offsetMagnitude > MAGNITUDE_THRESHOLD || offsetChange > CHANGE_THRESHOLD) {
+        const MAX_TILT = 45;
+        const clampTilt = (value) =>
+          Math.min(Math.max(value, -MAX_TILT), MAX_TILT) / MAX_TILT;
+
+        pendingImpulse.x = clampTilt(orientationOffset.gamma);
+        pendingImpulse.y = clampTilt(orientationOffset.beta);
+
+        baselineOrientation = { beta, gamma };
+        orientationOffset.beta = 0;
+        orientationOffset.gamma = 0;
+      }
+    }
+
+    function applyOrientationInfluence(ball) {
+      if (!motionEnabled) return;
+
+      const impulseMagnitude = Math.hypot(pendingImpulse.x, pendingImpulse.y);
+      if (impulseMagnitude === 0) return;
+
+      const steeringStrength = MAX_SPEED * 0.6;
+
+      ball.dx += pendingImpulse.x * steeringStrength;
+      ball.dy += pendingImpulse.y * steeringStrength;
+
+      pendingImpulse.x = 0;
+      pendingImpulse.y = 0;
+
+      clampSpeed(ball);
+    }
+
+    if (isMobileDevice) {
+      interactButton.hidden = false;
+
+      interactButton.addEventListener("click", async () => {
+        if (motionEnabled) {
+          resetBaseline();
+          interactButton.textContent = "Hold steady — recalibrated";
+          return;
+        }
+
+        resetBaseline();
+
+        try {
+          if (
+            typeof DeviceOrientationEvent !== "undefined" &&
+            typeof DeviceOrientationEvent.requestPermission === "function"
+          ) {
+            const permission = await DeviceOrientationEvent.requestPermission();
+            if (permission !== "granted") {
+              interactButton.textContent = "Permission denied";
+              return;
+            }
+          }
+
+          window.addEventListener("deviceorientation", handleOrientation, true);
+          motionEnabled = true;
+          interactButton.textContent = "Motion active — tap to recalibrate";
+        } catch (error) {
+          console.error("Device orientation error", error);
+          interactButton.textContent = "Unavailable";
+        }
+      });
+    }
   </script>
 </html>


### PR DESCRIPTION
## Summary
- gate mobile motion steering behind discrete impulses triggered by sharp tilt changes
- reset the motion baseline after each impulse so holding a tilt no longer continuously curves the night ball

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68da60827b5c832f8bf0d7de1aed5657