### PR TITLE
Implement mobile motion steering control

### DIFF
--- a/MOTION_CONTROL_PLAN.md
+++ b/MOTION_CONTROL_PLAN.md
@@ -1,0 +1,41 @@
+# Motion Control Balancing Plan
+
+This plan outlines the steps required to make the mobile motion control for the night ball feel responsive and intuitive while preventing overpowering or chaotic behavior.
+
+## 1. Establish a Baseline for Current Behavior
+- [ ] Add a temporary debug overlay that visualizes raw tilt (beta/gamma), filtered tilt, and the applied steering impulse so we can observe how current inputs map to ball movement.
+- [ ] Log tilt deltas, steering impulses, and resulting ball velocity vectors to the console (behind a debug flag) to quantify the current gain and damping.
+- [ ] Verify calibration flow on both iOS and Android to ensure baseline orientation is set exactly when the Interact button is pressed.
+
+## 2. Rework Orientation Processing
+- [ ] Split orientation tracking into three stages: calibration (baseline capture), filtering (low-pass to smooth jitter), and impulse detection (high-pass for quick tilts).
+- [ ] Replace the single smoothing factor with a complementary filter that blends low-frequency drift removal with high-frequency responsiveness.
+- [ ] Introduce adjustable sensitivity profiles (e.g., "subtle", "balanced", "aggressive") to fine-tune for different device sensor qualities during testing.
+
+## 3. Map Tilt to Steering Force
+- [ ] Convert filtered tilt angles to a normalized vector capped between -1 and 1 using a sigmoid curve so extreme tilts don't jump straight to full force.
+- [ ] Apply easing that ramps in force over ~150 ms to avoid sudden lateral spikes yet still feel immediate.
+- [ ] Add inverse damping proportional to the ball's current forward velocity to keep overall speed within bounds while allowing noticeable curvature.
+- [ ] After applying steering, re-clamp the total speed and project the velocity vector to maintain consistent kinetic energy.
+
+## 4. Preserve Player Intent While Avoiding Drift
+- [ ] Keep the ball's forward momentum oriented toward its current travel direction; steer by rotating the velocity vector rather than simply adding to dx/dy.
+- [ ] Reset the baseline automatically if the device remains steady for >2 seconds to prevent accumulation of offset drift.
+- [ ] Provide an optional "hold to steer" mode where the Interact button becomes a press-and-hold trigger that temporarily increases sensitivity for precise shots.
+
+## 5. Feedback & Accessibility
+- [ ] Update the UI copy to explain the feature and display the current sensitivity mode.
+- [ ] Show a subtle on-canvas arrow or glow on the night ball indicating the steering direction strength.
+- [ ] Ensure non-mobile users never see the motion UI, and mobile users can disable it entirely.
+
+## 6. Testing Strategy
+- [ ] Test on at least one iOS and one Android device, covering Safari, Chrome, and Firefox where possible.
+- [ ] Validate that small tilts (~5°) produce gentle arcs, medium tilts (~15°) create visible curvature, and extreme tilts (~30°+) result in near-max steering without losing control.
+- [ ] Confirm recalibration works mid-game and that sensitivity adjustments are respected immediately.
+- [ ] Gather subjective feedback from at least two testers to confirm the controls feel balanced.
+
+## 7. Cleanup
+- [ ] Remove temporary debug overlays and logs once tuning is complete.
+- [ ] Document the control behavior in the README, including calibration instructions and recommended device posture.
+
+Following this plan should deliver a motion-control experience that is responsive, predictable, and fun across both iOS and Android devices.

--- a/index.html
+++ b/index.html
@@ -53,6 +53,22 @@
         color: #172b36;
       }
 
+      #interactButton {
+        font-family: monospace;
+        margin-top: 20px;
+        padding: 10px 18px;
+        border: 1px solid #172b36;
+        background: rgba(241, 246, 244, 0.8);
+        color: #172b36;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.1s ease;
+      }
+
+      #interactButton:active {
+        transform: scale(0.98);
+      }
+
       #made {
         text-align: center;
         line-height: 1.5;
@@ -72,6 +88,7 @@
     <div id="container">
       <canvas id="pongCanvas" width="600" height="600"></canvas>
       <div id="score"></div>
+      <button id="interactButton" hidden>Auto pilot — tap to interact</button>
       <p id="made">
         made by
         <a href="https://koenvangilst.nl/labs/pong-wars">Koen van Gilst</a> | source on
@@ -96,6 +113,7 @@
     const canvas = document.getElementById("pongCanvas");
     const ctx = canvas.getContext("2d");
     const scoreElement = document.getElementById("score");
+    const interactButton = document.getElementById("interactButton");
 
     const DAY_COLOR = colorPalette.MysticMint;
     const DAY_BALL_COLOR = colorPalette.NocturnalExpedition;
@@ -201,12 +219,26 @@
     }
 
     function clampSpeed(ball) {
-      ball.dx = Math.min(Math.max(ball.dx, -MAX_SPEED), MAX_SPEED);
-      ball.dy = Math.min(Math.max(ball.dy, -MAX_SPEED), MAX_SPEED);
+      const speed = Math.hypot(ball.dx, ball.dy);
 
-      // Make sure the ball always maintains a minimum speed
-      if (Math.abs(ball.dx) < MIN_SPEED) ball.dx = ball.dx > 0 ? MIN_SPEED : -MIN_SPEED;
-      if (Math.abs(ball.dy) < MIN_SPEED) ball.dy = ball.dy > 0 ? MIN_SPEED : -MIN_SPEED;
+      if (speed === 0) {
+        ball.dx = MIN_SPEED;
+        ball.dy = 0;
+        return;
+      }
+
+      if (speed > MAX_SPEED) {
+        const scale = MAX_SPEED / speed;
+        ball.dx *= scale;
+        ball.dy *= scale;
+        return;
+      }
+
+      if (speed < MIN_SPEED) {
+        const scale = MIN_SPEED / speed;
+        ball.dx *= scale;
+        ball.dy *= scale;
+      }
     }
 
     function addRandomness(ball) {
@@ -278,6 +310,10 @@
         ball.y += ball.dy;
 
         addRandomness(ball);
+
+        if (ball === balls[1]) {
+          applyOrientationInfluence(ball);
+        }
       });
 
       handleBallCollisions();
@@ -288,5 +324,108 @@
 
     const FRAME_RATE = 100;
     setInterval(draw, 1000 / FRAME_RATE);
+
+    const isMobileDevice = /android|iphone|ipad|ipod/i.test(navigator.userAgent);
+
+    let motionEnabled = false;
+    let baselineOrientation = null;
+    let lastOrientation = null;
+    const tiltVector = { x: 0, y: 0 };
+    let orientationListenerAttached = false;
+
+    function calibrateBaseline() {
+      if (lastOrientation) {
+        baselineOrientation = { ...lastOrientation };
+      } else {
+        baselineOrientation = null;
+      }
+      tiltVector.x = 0;
+      tiltVector.y = 0;
+    }
+
+    function handleOrientation(event) {
+      const beta = event.beta ?? 0; // front-to-back tilt
+      const gamma = event.gamma ?? 0; // left-to-right tilt
+
+      lastOrientation = { beta, gamma };
+
+      if (!motionEnabled) return;
+
+      if (baselineOrientation === null) {
+        baselineOrientation = { beta, gamma };
+        tiltVector.x = 0;
+        tiltVector.y = 0;
+        return;
+      }
+
+      const deltaBeta = beta - baselineOrientation.beta;
+      const deltaGamma = gamma - baselineOrientation.gamma;
+
+      const MAX_TILT = 45;
+      const clamp = (value) => Math.min(Math.max(value, -MAX_TILT), MAX_TILT) / MAX_TILT;
+
+      const targetX = clamp(deltaGamma);
+      const targetY = clamp(deltaBeta);
+
+      const SMOOTHING = 0.2;
+      tiltVector.x += (targetX - tiltVector.x) * SMOOTHING;
+      tiltVector.y += (targetY - tiltVector.y) * SMOOTHING;
+    }
+
+    function applyOrientationInfluence(ball) {
+      if (!motionEnabled) return;
+
+      const steeringStrength = MAX_SPEED * 0.35;
+
+      ball.dx += tiltVector.x * steeringStrength;
+      ball.dy += tiltVector.y * steeringStrength;
+
+      clampSpeed(ball);
+    }
+
+    if (isMobileDevice) {
+      interactButton.hidden = false;
+
+      interactButton.addEventListener("click", async () => {
+        if (motionEnabled) {
+          motionEnabled = false;
+          baselineOrientation = null;
+          lastOrientation = null;
+          tiltVector.x = 0;
+          tiltVector.y = 0;
+          interactButton.textContent = "Auto pilot — tap to interact";
+          return;
+        }
+
+        try {
+          if (typeof DeviceOrientationEvent === "undefined") {
+            interactButton.textContent = "Unavailable";
+            return;
+          }
+
+          if (
+            typeof DeviceOrientationEvent.requestPermission === "function"
+          ) {
+            const permission = await DeviceOrientationEvent.requestPermission();
+            if (permission !== "granted") {
+              interactButton.textContent = "Permission denied";
+              return;
+            }
+          }
+
+          if (!orientationListenerAttached) {
+            window.addEventListener("deviceorientation", handleOrientation, true);
+            orientationListenerAttached = true;
+          }
+
+          motionEnabled = true;
+          calibrateBaseline();
+          interactButton.textContent = "Motion active — tap to stop";
+        } catch (error) {
+          console.error("Device orientation error", error);
+          interactButton.textContent = "Unavailable";
+        }
+      });
+    }
   </script>
 </html>


### PR DESCRIPTION
## Summary
- show a mobile-only Interact button that requests motion permission before enabling steering
- calibrate the current pose as the neutral baseline and translate tilt into steering impulses for the night ball
- let players tap the motion button again to drop back into auto pilot mode with steering disabled

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68da60827b5c832f8bf0d7de1aed5657